### PR TITLE
[triaina_pandas] win | preprocess2 | fix 

### DIFF
--- a/triaina_pandas_win/preprocess2/create_taxa_meta.py
+++ b/triaina_pandas_win/preprocess2/create_taxa_meta.py
@@ -132,17 +132,19 @@ def set_remote_size(output_path, df, taxa, p_id, is_purge):
 def is_downloaded(row, ftp_con, df_len, taxa, p_id):
     remote_path = row["remote_path"]
     output_path = row["local_path"]
-    local_size = os.path.getsize(output_path)
-    remote_size = row["remote_size"]
     
-    if local_size == remote_size:
-        print("Downloaded already")
-        return row
+    local_size = -1
+    if os.path.exists(output_path):
+        local_size = os.path.getsize(output_path)
+    remote_size = row["remote_size"]
     
     if remote_size == -1:
         print("Not found remote file")
         return row
-    
+    if local_size == remote_size:
+        print("Downloaded already")
+        return row
+        
     try:
         ftp_con.download(output_path, remote_path, remote_size)
     except:

--- a/triaina_pandas_win/preprocess2/parallel_process.py
+++ b/triaina_pandas_win/preprocess2/parallel_process.py
@@ -47,7 +47,6 @@ if __name__ == '__main__':
         print(f"{t2-t1:.3f} sec")
         
         df_ = df[df["is_downloaded"] == False]
-        print(f"number of file : f{df_}")
         # t3 = time()
         taxa_data_process(df_, n_procs, is_purge)
         t4 = time()


### PR DESCRIPTION
parallel_process : remove print(len(df) cuz using cpu 100%
create_taxa_meta : refactoring for local_size in is_downloaded
